### PR TITLE
chore: add session_box dependency and update related package versions

### DIFF
--- a/lib/features/tracking/application/services/tracking_notification_service.dart
+++ b/lib/features/tracking/application/services/tracking_notification_service.dart
@@ -24,7 +24,7 @@ final class TrackerNotificationService {
     const settings = InitializationSettings(android: androidSettings);
 
     await _plugin.initialize(
-      settings,
+      settings: settings,
       onDidReceiveNotificationResponse: onTap,
     );
 
@@ -59,15 +59,15 @@ final class TrackerNotificationService {
     const details = NotificationDetails(android: android);
 
     await _plugin.show(
-      NotificationConstants.notificationId,
-      title,
-      body,
-      details,
+      id: NotificationConstants.notificationId,
+      title: title,
+      body: body,
+      notificationDetails: details,
       payload: payload,
     );
   }
 
   Future<void> cancelTracker() {
-    return _plugin.cancel(NotificationConstants.notificationId);
+    return _plugin.cancel(id: NotificationConstants.notificationId);
   }
 }

--- a/pubspec-foss.lock
+++ b/pubspec-foss.lock
@@ -1380,6 +1380,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  session_box:
+    dependency: "direct main"
+    description:
+      name: session_box
+      sha256: "5306604db8474fbf7bd95b85a9dce04270358938c84b28d68d7e6a317ef7f54d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec-foss.yaml
+++ b/pubspec-foss.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   android_intent_plus: ^6.0.0
-  auto_route: ^10.1.2
+  auto_route: ^11.1.0
   battery_plus: ^7.0.0
   connectivity_plus: ^7.0.0
   country: ^6.0.3
@@ -52,6 +52,7 @@ dependencies:
   permission_handler: ^12.0.1
   provider: ^6.1.5+1
   pub_semver: ^2.2.0
+  session_box: ^1.0.5
   shared_preferences: ^2.5.4
   shimmer: ^3.0.0
   sqlcipher_flutter_libs: ^0.6.8

--- a/pubspec-gms.lock
+++ b/pubspec-gms.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
       url: "https://pub.dev"
     source: hosted
-    version: "92.0.0"
+    version: "93.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.0.1"
   android_intent_plus:
     dependency: "direct main"
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: "direct dev"
     description:
       name: auto_route_generator
-      sha256: "04300eaf5821962aae8b5cd94f67013fd2fd326dc3be212d3ec1ae7470f09834"
+      sha256: "7aa0e90874928e78709f0a21a69fb5bc2ae1aa932dec862930d2af85c40adb01"
       url: "https://pub.dev"
     source: hosted
-    version: "10.4.0"
+    version: "10.5.0"
   battery_plus:
     dependency: "direct main"
     description:
@@ -341,10 +341,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: "15a7db352c8fc6a4d2bc475ba901c25b39fe7157541da4c16eacce6f8be83e49"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.5"
   dawarich_android_user_module:
     dependency: "direct main"
     description:
@@ -997,10 +997,10 @@ packages:
     dependency: transitive
     description:
       name: lean_builder
-      sha256: "6af3cfbf34400eb14b89fe20111e5981e7083362f00ea10b9ed2a6e833250d76"
+      sha256: ee4117b03e93a4eb83e1a78c8e7a1dc22188d43bb142309982be48673a1b3a53
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.6"
+    version: "0.1.7"
   lints:
     dependency: transitive
     description:
@@ -1377,6 +1377,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  session_box:
+    dependency: "direct main"
+    description:
+      name: session_box
+      sha256: "5306604db8474fbf7bd95b85a9dce04270358938c84b28d68d7e6a317ef7f54d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1682,10 +1690,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.1"
   web:
     dependency: transitive
     description:

--- a/pubspec-gms.yaml
+++ b/pubspec-gms.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   android_intent_plus: ^6.0.0
-  auto_route: ^10.1.2
+  auto_route: ^11.1.0
   battery_plus: ^7.0.0
   connectivity_plus: ^7.0.0
   country: ^6.0.3
@@ -48,6 +48,7 @@ dependencies:
   permission_handler: ^12.0.1
   provider: ^6.1.5+1
   pub_semver: ^2.2.0
+  session_box: ^1.0.5
   shared_preferences: ^2.5.4
   shimmer: ^3.0.0
   sqlcipher_flutter_libs: ^0.6.8

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1377,6 +1377,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  session_box:
+    dependency: "direct main"
+    description:
+      name: session_box
+      sha256: "5306604db8474fbf7bd95b85a9dce04270358938c84b28d68d7e6a317ef7f54d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   permission_handler: ^12.0.1
   provider: ^6.1.5+1
   pub_semver: ^2.2.0
+  session_box: ^1.0.5
   shared_preferences: ^2.5.4
   shimmer: ^3.0.0
   sqlcipher_flutter_libs: ^0.6.8
@@ -57,7 +58,7 @@ dependencies:
   cupertino_icons: ^1.0.8
 
 dev_dependencies:
-  auto_route_generator: ^10.5.0
+  auto_route_generator: ^10.4.0
   build_runner: ^2.11.1
   drift_dev: ^2.31.0
   flutter_launcher_icons: ^0.14.4


### PR DESCRIPTION
- Add session_box: ^1.0.5 to all pubspec variants and lock files
- Update auto_route and auto_route_generator versions in FOSS and GMS configs
- Update several transitive dependencies in pubspec-gms.lock
- Fix parameter usage for plugin methods in tracking_notification_service.dart to match latest API