### PR TITLE
Add F-Droid download badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@
 </p>
 
 <p align="center">
+  <a href="https://f-droid.org/packages/YOUR.APP.ID">
+    <img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
+    alt="Get it on F-Droid"
+    height="80">
+</a>
   <a href="https://play.google.com/store/apps/details?id=com.sunstep.dawarich">
     <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" height="80" alt="Get it on Google Play" />
   </a>


### PR DESCRIPTION
Added F-Droid badge for app download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added F-Droid download badge: A new centered download badge has been added to the project documentation, displaying official F-Droid artwork and providing users with a direct link to download the application from F-Droid's app store. This offers users an alternative download option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->